### PR TITLE
fix: force use of /bin/bash over /bin/sh; add more logging

### DIFF
--- a/src/commands/generate_tags.yml
+++ b/src/commands/generate_tags.yml
@@ -4,15 +4,16 @@ parameters:
   outfile:
     type: string
     default: tags.txt
-    description: "The file to output the list of tags to."
+    description: The file to output the list of tags to.
   package:
     type: string
     default: ""
-    description: "Optional tag prefix, such as those used in Go monorepos."
+    description: Optional tag prefix, such as those used in Go monorepos.
 steps:
   - run:
       environment:
         PARAM_OUTFILE: << parameters.outfile >>
         PARAM_PACKAGE: << parameters.package >>
       name: Generate Tags
+      shell: /bin/bash
       command: <<include(scripts/generate_tags.sh)>>

--- a/src/commands/populate_image_uri.yml
+++ b/src/commands/populate_image_uri.yml
@@ -19,4 +19,5 @@ steps:
         PARAM_IMAGE_URI_ENV_VAR: << parameters.image_uri_env_var >>
         PARAM_TAG_ENV_VAR: << parameters.tag_env_var >>
       name: Populate Image URI Environment Variable
+      shell: /bin/bash
       command: <<include(scripts/populate_image_uri.sh)>>

--- a/src/commands/populate_image_uri_digest.yml
+++ b/src/commands/populate_image_uri_digest.yml
@@ -15,4 +15,5 @@ steps:
         PARAM_IMAGE_URI_ENV_VAR: << parameters.image_uri_env_var >>
         PARAM_IMAGE_URI_DIGEST_ENV_VAR: << parameters.image_digest_env_var >>
       name: Populate Image URI Digest Environment Variable
+      shell: /bin/bash
       command: <<include(scripts/populate_image_uri_digest.sh)>>

--- a/src/commands/populate_tag.yml
+++ b/src/commands/populate_tag.yml
@@ -15,4 +15,5 @@ steps:
         PARAM_PACKAGE: << parameters.package >>
         PARAM_TAG_ENV_VAR: << parameters.tag_env_var >>
       name: Populate Tag Environment Variable
+      shell: /bin/bash
       command: <<include(scripts/populate_tag.sh)>>

--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -20,4 +20,5 @@ steps:
         PARAM_TARGET_IMAGE: << parameters.target_image >>
         PARAM_TOOL: << parameters.tool >>
       name: Push Tagged Images To Registry
+      shell: /bin/bash
       command: <<include(scripts/push.sh)>>

--- a/src/commands/tag.yml
+++ b/src/commands/tag.yml
@@ -34,4 +34,5 @@ steps:
         PARAM_TARGET_IMAGE: << parameters.target_image >>
         PARAM_TOOL: << parameters.tool >>
       name: Apply Tags To Container Image
+      shell: /bin/bash
       command: <<include(scripts/tag.sh)>>

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -8,7 +8,7 @@ usage:
   jobs:
     sign-images:
       docker:
-        - image: cimg/base:stable
+        - image: cimg/base:current-22.04
       steps:
         - tagger/generate_tags
         - tagger/tag:

--- a/src/scripts/generate_tags.sh
+++ b/src/scripts/generate_tags.sh
@@ -1,63 +1,92 @@
 #!/bin/bash
 
 set -e
+set +o history
 
 # Read command arguments
 OUTFILE=$(circleci env subst "${PARAM_OUTFILE}")
 PACKAGE=$(circleci env subst "${PARAM_PACKAGE}")
 
 # Print arguments for debugging purposes
-echo "Generating tags for container image..."
+echo "Input arguments for tag generation command:"
 echo "  CIRCLE_BRANCH: ${CIRCLE_BRANCH}"
 echo "  CIRCLE_BUILD_NUM: ${CIRCLE_BUILD_NUM}"
 echo "  CIRCLE_SHA1: ${CIRCLE_SHA1}"
 echo "  CIRCLE_TAG: ${CIRCLE_TAG}"
 echo "  OUTFILE: ${OUTFILE}"
 echo "  PACKAGE: ${PACKAGE}"
+echo ""
 
 # Reset the output file, in case the script is ran multiple times.
+echo "Truncating ${OUTFILE}..."
 truncate -s 0 "${OUTFILE}"
+echo "  Done."
+echo ""
 
-SHORT_REVISION=${CIRCLE_SHA1:0:8}
+echo "Generating tags:"
+SHORT_REVISION=$(echo "${CIRCLE_SHA1}" | cut -c 1-8)
+echo "  SHORT_REVISION: ${SHORT_REVISION}"
+TAG="${CIRCLE_TAG#"${PACKAGE}/"}"
+echo "  TAG: ${TAG}"
 
 if [[ "$CIRCLE_TAG" =~ v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9]+)?$ ]]; then
-    TAG="${CIRCLE_TAG#"${PACKAGE}/"}"
+    echo "  Processing release as a new tag. The CIRCLE_TAG env var contained a valid semantic version."
     echo "${TAG#v}" >> "${OUTFILE}"
+    echo "  Added tag to file: ${TAG#v}"
 
     MAJOR_VER=$(echo "${TAG}" | cut -c 2- | cut -d . -f 1)
+    echo "  MAJOR_VER: ${MAJOR_VER}"
     MINOR_VER=$(echo "${TAG}" | cut -c 2- | cut -d . -f 2)
+    echo "  MINOR_VER: ${MINOR_VER}"
     if [[ "${TAG}" =~ -(alpha|beta|rc)[0-9]+$ ]]; then
         PRERELEASE_VER=$(echo "${TAG}" | cut -d '-' -f 2 | cut -c 3-)
     fi
+    echo "  PRERELEASE_VER: ${PRERELEASE_VER}"
 
     ADDED_TAG=$TAG
     if [[ -n "$PACKAGE" ]]; then
         ADDED_TAG="${PACKAGE}/${TAG}"
     fi
+    echo "  ADDED_TAG: ${ADDED_TAG}"
 
     HIGHEST_VERSION=$({ git tag; echo "${ADDED_TAG}"; } | grep "^${PACKAGE}" |  sed "s#${PACKAGE}/##" | grep -E -i 'v[0-9]+\.[0-9]+\.[0-9]+$' | sort -r --version-sort | head -n 1)
+    echo "  HIGHEST_VERSION: ${HIGHEST_VERSION}"
     HIGHEST_WITH_SAME_MAJOR=$({ git tag; echo "${ADDED_TAG}"; } | grep "^${PACKAGE}" | sed "s#${PACKAGE}/##" | grep -E -i 'v[0-9]+\.[0-9]+\.[0-9]+$' | grep -i "v${MAJOR_VER}." | sort -r --version-sort | head -n 1)
+    echo "  HIGHEST_WITH_SAME_MAJOR: ${HIGHEST_WITH_SAME_MAJOR}"
     HIGHEST_WITH_SAME_MINOR=$({ git tag; echo "${ADDED_TAG}"; } | grep "^${PACKAGE}" | sed "s#${PACKAGE}/##" | grep -E -i 'v[0-9]+\.[0-9]+\.[0-9]+$' | grep -i "v${MAJOR_VER}.${MINOR_VER}." | sort -r --version-sort | head -n 1)
+    echo "  HIGHEST_WITH_SAME_MINOR: ${HIGHEST_WITH_SAME_MINOR}"
 
     if [[ -z ${PRERELEASE_VER} ]]; then
+        echo "  This is a final release. Generating latest, major, and minor tags..."
+
         if [[ ${TAG} == "${HIGHEST_WITH_SAME_MINOR}" ]] ; then
 	        echo "${MAJOR_VER}.${MINOR_VER}" >> "${OUTFILE}"
+            echo "  Added tag to output file: ${MAJOR_VER}.${MINOR_VER}"
         fi
 
         if [[ ${TAG} == "${HIGHEST_WITH_SAME_MAJOR}" ]] ; then
 	        echo "${MAJOR_VER}" >> "${OUTFILE}"
+            echo "  Added tag to output file: ${MAJOR_VER}"
         fi
 
         if [[ ${TAG} == "${HIGHEST_VERSION}" ]] ; then
 	        echo "latest" >> "${OUTFILE}"
+            echo "  Added tag to output file: latest"
         fi
+    else
+        echo "  This is a pre-release. Not creating latest, major, or minor tags."
     fi
 elif [ "$CIRCLE_BRANCH" = develop ] || [ "$CIRCLE_BRANCH" = main ] || [ "$CIRCLE_BRANCH" = master ]; then
+    echo "  Processing as a merged pull request. The CIRCLE_BRANCH was set to a known trunk branch."
     echo "edge" >> "${OUTFILE}"
     echo "${CIRCLE_BRANCH}-${SHORT_REVISION}" >> "${OUTFILE}"
+    echo "  Added tag to output file: ${CIRCLE_BRANCH}-${SHORT_REVISION}"
 else
+    echo "  Processing as a commit to a development branch."
     echo "dev-${SHORT_REVISION}" >> "${OUTFILE}"
+    echo "  Added tag to output file: dev-${SHORT_REVISION}"
 fi
+echo "  Done."
 
 printf "\nThe following tags were generated:\n"
-awk '{print "   :"$1}' "${OUTFILE}"
+awk '{print "  :"$1}' "${OUTFILE}"

--- a/src/scripts/populate_image_uri.sh
+++ b/src/scripts/populate_image_uri.sh
@@ -4,6 +4,7 @@
 # This ensures future steps within the same job have access to it.
 
 set -e
+set +o history
 
 # ==========================================
 # Handle Input 

--- a/src/scripts/populate_image_uri_digest.sh
+++ b/src/scripts/populate_image_uri_digest.sh
@@ -5,6 +5,7 @@
 # have access to it.
 
 set -e
+set +o history
 
 # ==========================================
 # Handle Input 

--- a/src/scripts/populate_tag.sh
+++ b/src/scripts/populate_tag.sh
@@ -4,6 +4,7 @@
 # This ensures future steps within the same job have access to it.
 
 set -e
+set +o history
 
 # ==========================================
 # Handle Input 

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set +o history
 
 # Read command arguments
 TAGS_FILE=$(circleci env subst "${PARAM_TAGS_FILE}")

--- a/src/scripts/tag.sh
+++ b/src/scripts/tag.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set +o history
 
 # Read command arguments
 APPEND_TAGS_TO_SOURCE="${PARAM_APPEND_TAGS_TO_SOURCE}"


### PR DESCRIPTION
Despite `#!/bin/bash` being declared at the top of each script, using `<<include(script_name.sh)>>` within CircleCI appeared to result in the script executing with `/bin/sh`. This caused the scripts to throw errors when they reached bash-specific syntax or features. E.g., `${CIRCLE_SHA1:0:8}` only appears to work in Bash, whereas `$(echo "${CIRCLE_SHA1}" | cut -c 1-8)` works in both.

Fixes:
- Force use of `/bin/bash` over `/bin/sh` when executing scripts.
- Replaced bash-specific syntax used to compute the shortened SHA-1 digest.
- Added additional logging to the `tagger/generate_tags` command.
- Added `set +o history` to all scripts as a precautionary measure that many people use to limit exposure of secrets.