### PR TITLE
fix: small improvements to cci output and logging

### DIFF
--- a/src/commands/tag.yml
+++ b/src/commands/tag.yml
@@ -28,7 +28,6 @@ steps:
   - run:
       environment:
         PARAM_APPEND_TAGS_TO_SOURCE: << parameters.append_tags_to_source >>
-        PARAM_PUSH: << parameters.push >>
         PARAM_SOURCE_IMAGE: << parameters.source_image >>
         PARAM_TAGS_FILE: << parameters.tags_file >>
         PARAM_TARGET_IMAGE: << parameters.target_image >>
@@ -36,3 +35,14 @@ steps:
       name: Apply Tags To Container Image
       shell: /bin/bash
       command: <<include(scripts/tag.sh)>>
+  - when:
+      condition: << parameters.push >>
+      steps:
+        - run:
+            environment:
+              PARAM_TAGS_FILE: << parameters.tags_file >>
+              PARAM_TARGET_IMAGE: << parameters.target_image >>
+              PARAM_TOOL: << parameters.tool >>
+            name: Push Tagged Images To Registry
+            shell: /bin/bash
+            command: <<include(scripts/push.sh)>>

--- a/src/scripts/generate_tags.sh
+++ b/src/scripts/generate_tags.sh
@@ -17,6 +17,11 @@ echo "  OUTFILE: ${OUTFILE}"
 echo "  PACKAGE: ${PACKAGE}"
 echo ""
 
+echo "Computing absolute path for output tag file..."
+OUTFILE=$(realpath --no-symlinks "${OUTFILE}")
+echo "  OUTFILE: ${OUTFILE}"
+echo ""
+
 # Reset the output file, in case the script is ran multiple times.
 echo "Truncating ${OUTFILE}..."
 truncate -s 0 "${OUTFILE}"
@@ -87,6 +92,7 @@ else
     echo "  Added tag to output file: dev-${SHORT_REVISION}"
 fi
 echo "  Done."
+echo ""
 
-printf "\nThe following tags were generated:\n"
+echo "The following tags were generated and written to ${OUTFILE}:"
 awk '{print "  :"$1}' "${OUTFILE}"

--- a/src/scripts/tag.sh
+++ b/src/scripts/tag.sh
@@ -5,7 +5,6 @@ set +o history
 
 # Read command arguments
 APPEND_TAGS_TO_SOURCE="${PARAM_APPEND_TAGS_TO_SOURCE}"
-PUSH="${PARAM_PUSH}"
 TAGS_FILE=$(circleci env subst "${PARAM_TAGS_FILE}")
 SOURCE_IMAGE=$(circleci env subst "${PARAM_SOURCE_IMAGE}")
 TARGET_IMAGE=$(circleci env subst "${PARAM_TARGET_IMAGE}")
@@ -13,7 +12,6 @@ TOOL="${PARAM_TOOL}"
 
 # Print arguments for debugging purposes
 echo "Running tagger with arguments:"
-echo "  PUSH: ${PUSH}"
 echo "  TAGS_FILE: ${TAGS_FILE}"
 echo "  SOURCE_IMAGE: ${SOURCE_IMAGE}"
 echo "  TARGET_IMAGE: ${TARGET_IMAGE}"
@@ -54,9 +52,4 @@ while read -r TAG; do
 
     echo "Tagging image: ${TARGET_IMAGE}:${TAG}..."
     "${TOOL}" tag "${INNER_SOURCE_IMAGE}" "${TARGET_IMAGE}:${TAG}"
-
-    if [[ "${PUSH}" == "1" ]]; then
-        echo "Pushing image: ${TARGET_IMAGE}:${TAG}..."
-        "${TOOL}" push "${TARGET_IMAGE}:${TAG}"
-    fi
 done < "${TAGS_FILE}"


### PR DESCRIPTION
- When the `push: true` parameter is supplied to the `tagger/tag` command, this orb will now create a separate step that is clearly labeled "Push Tagged Images To Registry". Previously images could get pushed in a step that was labeled "Apply Tags To Container Image", which was misleading and confusing.
- The `tagger/generate_tags` command will now print the full file path of the tag file for debugging purposes. Previously it could print a relative path.